### PR TITLE
Replace deprecated `ugettext_lazy` (for Django 4.0)

### DIFF
--- a/simplemathcaptcha/widgets.py
+++ b/simplemathcaptcha/widgets.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.template.defaultfilters import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .utils import hash_answer, get_operator, get_numbers, calculate
 


### PR DESCRIPTION
The `ugettext_lazy` alias for `gettext_lazy` was removed in Django 4.0.